### PR TITLE
feat: Improve `recover` task with performance updates by running ANALYSE before recovering materialized views

### DIFF
--- a/src/edwh_devdb_plugin/devdb_plugin.py
+++ b/src/edwh_devdb_plugin/devdb_plugin.py
@@ -105,11 +105,6 @@ def setup(c: Context):
     )
 
 
-"""
-Todo:
-- don't harcode tables to exclude
-- load from `default.toml` or `.toml` (c
-"""
 
 
 def find_devdb_config():

--- a/src/edwh_devdb_plugin/devdb_plugin.py
+++ b/src/edwh_devdb_plugin/devdb_plugin.py
@@ -402,7 +402,12 @@ def recover(ctx: Context, name: str = "snapshot"):
             warn=True,
         )
 
-        input('⏳️ Enter to continue.')
+        print("Running ANALYZE to update database statistics...")
+        analyze_cmd = (f"{DOCKER_COMPOSE} run -T --rm --no-deps migrate "
+                       f"psql -d \"{postgres_uri}\" -c \"ANALYZE VERBOSE;\"")
+        analyze_result = ctx.run(analyze_cmd, hide=True, warn=True)
+        if not analyze_result.ok:
+            cprint(f"Database ANALYZE failed. Stderr:\n{analyze_result.stderr}", color="yellow")
 
         if not (no_mat_result and no_mat_result.ok):
             cprint("Error restoring non-materialized views.", color="red")


### PR DESCRIPTION
### Summary of Changes
- Added a database statistics update with `ANALYZE` to speed up the rematerialization process.
- Fixed PostgreSQL URI handling and applied tighter permission checks in the `recover` task.
- Enhanced temporary directory management for better reliability.
- Introduced materialized view filtering and optimized the restore process to improve task efficiency.
- Removed an outdated TODO comment in `devdb_plugin.py` for better code clarity.
